### PR TITLE
DAT-20303: use GITHUB_TOKEN instead of BOT_TOKEN

### DIFF
--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -22,7 +22,6 @@ jobs:
       dry_run_release_id: ${{ steps.get_draft_release_id.outputs.release_id }}
   
   
-  
     steps:
       - name: Get Draft Release ID 
         id: get_draft_release_id


### PR DESCRIPTION
This pull request updates the `.github/workflows/dry-run-release.yml` file to enhance security and streamline the retrieval of draft release IDs. The most important changes include adding permissions for read-only access to repository contents and replacing the use of `BOT_TOKEN` with `GH_TOKEN` for authentication.

I see that this run had failed previously due to the BOT_TOKEN and never run successfully. But this change would suffice for now. @filipelautert :I see the workflow is disabled. I'd still like to merge this PR

<img width="1367" alt="Screenshot 2025-06-02 at 2 07 14 PM" src="https://github.com/user-attachments/assets/39098ba4-4f70-40d4-bd3a-3061ac2aaff5" />


Enhancements to security and workflow:

* [`.github/workflows/dry-run-release.yml`](diffhunk://#diff-da505eba40e5178912154d1d165e17f3353098ba24e44bd62d23ad028700e42aR23-R33): Added `permissions` block with `contents: read` to restrict access to repository contents to read-only.
* [`.github/workflows/dry-run-release.yml`](diffhunk://#diff-da505eba40e5178912154d1d165e17f3353098ba24e44bd62d23ad028700e42aR23-R33): Replaced `BOT_TOKEN` with `GH_TOKEN` for authentication and set `GH_TOKEN` as an environment variable in the workflow step. This improves security by using GitHub's built-in token management.