### PR TITLE
run integration tests in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
     secrets: inherit
     with:
       java: "[ 17, 21 ]"
+      runIntegrationTests: true
 
   dependabot:
     needs: build-test


### PR DESCRIPTION
this parameter was newly introduced: https://github.com/liquibase/build-logic/pull/365 using this instead of manually running the tests (as is done in `liquibase-opensearch` right now) ensures that the test report files are being picked up and processed by Sonar. if this isn't done and the repo doesn't include any unit tests the sonar workflow would instead fail.