### PR TITLE
fix repo URL in `pom.xml`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
 
     <description>Liquibase extension to manage changesets for OpenSearch.</description>
-    <url>https://github.com/liquibase/liquibase-opensearch-springboot-starter</url>
+    <url>https://github.com/liquibase/liquibase-opensearch-spring-boot-starter</url>
 
     <licenses>
         <license>


### PR DESCRIPTION
the repo has been renamed, so the URL needs to be adapted. there's a redirect from the old to the new URL, so both work.