### PR TITLE
drop JDK 17 from CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@main
     secrets: inherit
     with:
-      java: "[ 17, 21 ]"
+      java: "[ 21 ]"
       runIntegrationTests: true
 
   dependabot:


### PR DESCRIPTION
with the upgrade to the latest OpenSearch libraries we have to drop JDK 17 support due to `opensearch-testcontainers` (see #46). as the workflow uses `pull_request_target` we have to merge this before we can successfully run the CI on the upgrade PR as it doesn't pick it up in the PR modifying it.