### PR TITLE
update to `spring-data-opensearch` v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased] - ReleaseDate
+
+### Changed
+
+* Updated to `spring-data-opensearch` v2 & `opensearch-java` v3 - this is a breaking change for consumers!
+  * Require JDK 21 as a minimum due to this update
+
+[Unreleased]: https://github.com/liquibase/liquibase-opensearch/compare/v0.0.1...HEAD

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Please refer to [`liquibase-opensearch`] to see the current compatibility.
 
 This project follows the [spring boot release cycle] and thus **does not** adhere to [Semantic Versioning].
 
+## Changelog
+For the changelog please see the dedicated [CHANGELOG.md](CHANGELOG.md).
+
 ## License
 This project is licensed under the Apache License Version 2.0 - see the [LICENSE] file for details.
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <properties>
         <liquibase.version>4.33.0</liquibase.version>
         <spring-boot.version>3.5.5</spring-boot.version>
-        <spring-data-opensearch.version>1.8.1</spring-data-opensearch.version>
+        <spring-data-opensearch.version>2.0.0</spring-data-opensearch.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <sonar.organization>liquibase</sonar.organization>
@@ -69,12 +69,12 @@
         <dependency>
             <groupId>org.liquibase.ext</groupId>
             <artifactId>liquibase-opensearch</artifactId>
-            <version>0.0.1</version>
+            <version>0.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.opensearch.client</groupId>
             <artifactId>opensearch-java</artifactId>
-            <version>2.26.0</version>
+            <version>3.2.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.opensearch.client</groupId>
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>org.opensearch</groupId>
             <artifactId>opensearch-testcontainers</artifactId>
-            <version>2.1.4</version>
+            <version>3.0.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/liquibase/ext/opensearch/integration/spring/SpringLiquibaseOpenSearchDisabledIT.java
+++ b/src/test/java/liquibase/ext/opensearch/integration/spring/SpringLiquibaseOpenSearchDisabledIT.java
@@ -3,7 +3,7 @@ package liquibase.ext.opensearch.integration.spring;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.opensearch.OpenSearchClient;
-import org.opensearch.testcontainers.OpensearchContainer;
+import org.opensearch.testcontainers.OpenSearchContainer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
@@ -22,7 +22,7 @@ class SpringLiquibaseOpenSearchDisabledIT {
 
     @Container
     @ServiceConnection
-    protected static OpensearchContainer<?> container = new OpensearchContainer<>(DockerImageName.parse(OPENSEARCH_DOCKER_IMAGE_NAME));
+    protected static OpenSearchContainer<?> container = new OpenSearchContainer<>(DockerImageName.parse(OPENSEARCH_DOCKER_IMAGE_NAME));
 
     @Autowired
     private OpenSearchClient openSearchClient;

--- a/src/test/java/liquibase/ext/opensearch/integration/spring/SpringLiquibaseOpenSearchIT.java
+++ b/src/test/java/liquibase/ext/opensearch/integration/spring/SpringLiquibaseOpenSearchIT.java
@@ -4,7 +4,7 @@ import lombok.SneakyThrows;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.opensearch.OpenSearchClient;
-import org.opensearch.testcontainers.OpensearchContainer;
+import org.opensearch.testcontainers.OpenSearchContainer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
@@ -24,7 +24,7 @@ class SpringLiquibaseOpenSearchIT {
 
     @Container
     @ServiceConnection
-    protected static OpensearchContainer<?> container = new OpensearchContainer<>(DockerImageName.parse(OPENSEARCH_DOCKER_IMAGE_NAME));
+    protected static OpenSearchContainer<?> container = new OpenSearchContainer<>(DockerImageName.parse(OPENSEARCH_DOCKER_IMAGE_NAME));
 
     @Autowired
     private OpenSearchClient openSearchClient;


### PR DESCRIPTION
due to the use of `@ServiceConnection` in the tests (which we could remove) we also need the newer `opensearch-testcontainers` version (as that is used in the newer SB integration) which in turn forces us to build only with JDK 21. technically this is only for the test sources, however the way liquibase workflows work we have to use the same version for main and test sources and thus drop support for older JDKs.

this is the first notable change since the initial v0.0.1 release, accordingly i've now introduced a changelog.