### PR TITLE
CI: explicitly build with JDK 21

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
     secrets: inherit
     with:
       java: "[ 21 ]"
+      javaBuildVersion: 21
       runIntegrationTests: true
 
   dependabot:


### PR DESCRIPTION
turns out that the `java` parameter is not enough, `javaBuildVersion` is also needed. this is a follow-up to commit 0c9f901.