### PR TITLE
use JDK 21 for CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,3 +20,4 @@ jobs:
     secrets: inherit
     with:
       languages: '["java"]'
+      javaBuildVersion: 21


### PR DESCRIPTION
this is another preparation for the upgrade of the OpenSearch libraries. this requires liquibase/build-logic#391