### PR TITLE
TECHOPS-646: Pin step-level GitHub Actions to commit SHA

### DIFF
--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -61,7 +61,7 @@ jobs:
     needs: [dry-run-get-draft-release, dry-run-release-published]
     steps:
       - name: Checkout liquibase
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up Git
         run: |
@@ -93,21 +93,21 @@ jobs:
       ]
     steps:
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Get secrets from vault
         id: vault-secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v3
+        uses: aws-actions/aws-secretsmanager-get-secrets@2cb1a461cbd4865ac4299648312e4704c646cd53 # v3
         with:
           secret-ids: |
             ,/vault/liquibase
           parse-json-secrets: true
 
       - name: Notify Slack on Build Failure
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58 # v2
         env:
           SLACK_COLOR: failure
           SLACK_MESSAGE: "View details on GitHub Actions: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} <@U040C8J8143> <@U04P39MS2SW> <@UHHJ6UAEQ> <@U042HRTL4DT>" # Jandro, Sailee, Jake, Filipe

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -10,7 +10,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Validate PR Labels
-        uses: mheap/github-action-required-labels@v5
+        uses: mheap/github-action-required-labels@0ac283b4e65c1fb28ce6079dea5546ceca98ccbe # v5
         with:
           mode: minimum
           count: 1


### PR DESCRIPTION
## 📋 Overview
Pins **step-level** `uses:` references to full-length commit SHAs, per the enterprise Actions SHA-pinning policy. Tracked in [TECHOPS-646](https://datical.atlassian.net/browse/TECHOPS-646) (relates to [TECHOPS-81](https://datical.atlassian.net/browse/TECHOPS-81)).

Step-level action references are enforced by **"Require actions to be pinned to a full-length commit SHA"**; job-level reusable-workflow refs (`*.yml@main`) are exempt. These refs were still pinned to tags/branches and would fail once enforcement is enabled.

## 🔧 Changes
- Replaced tag/branch refs with the resolved full commit SHA.
- Original ref preserved as a trailing `# <ref>` comment.
- Only active (non-commented) step-level references changed.

## ✅ Testing
- SHAs resolved via the GitHub API against current tag/branch HEAD.
- Post-change verification confirmed 0 remaining unpinned active step-level refs in the edited files.

## ⚠️ Notes
- No functional change: same action code, now immutably referenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TECHOPS-646]: https://datical.atlassian.net/browse/TECHOPS-646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TECHOPS-81]: https://datical.atlassian.net/browse/TECHOPS-81?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ